### PR TITLE
godbolt's compiler explorer

### DIFF
--- a/domains
+++ b/domains
@@ -206,3 +206,4 @@
 .codesandbox.io
 .spotify.com
 .scdn.co
+.godbolt.org


### PR DESCRIPTION
the godbolt compiler explorer is IP blocked in iran by godbolt himself i emailed him about this and he told me that the eulas for some compilers doesnt allow iranians to use it so i thought it would be a good to add this website to FoD because iranians deserve to explore compilers now don't we?