### PR TITLE
Add i.stack.imgur.com

### DIFF
--- a/domains
+++ b/domains
@@ -12,6 +12,7 @@
 .jhipster.tech
 .classroom.google.com
 .c9.io
+.coursehero.com
 .edx.org
 .php.net
 .githubusercontent.com

--- a/domains
+++ b/domains
@@ -221,3 +221,4 @@
 .freecodecamp.org
 .libraries.io
 .githubassets.com
+.i.stack.imgur.com


### PR DESCRIPTION
Add i.stack.imgur.com to get rid of stackoverflow.com images problem.
Thanks