### PR TITLE
🔎 add algolia.com to domains

### DIFF
--- a/domains
+++ b/domains
@@ -27,6 +27,7 @@
 .githubusercontent.com
 .slack.com
 .play.google.com
+.algolia.com
 .developer.google.com
 .photodune.net
 .videohive.net

--- a/domains
+++ b/domains
@@ -28,6 +28,7 @@
 .slack.com
 .play.google.com
 .algolia.com
+.algolianet.com
 .developer.google.com
 .photodune.net
 .videohive.net


### PR DESCRIPTION
algolia.com's API used in other sites for searching. For example [Material UI site](https://material-ui.com/) use it. As you can see this domain blocks Iranian IPs.
![image](https://user-images.githubusercontent.com/29185622/62834929-f2a40680-bc67-11e9-90fa-ea0f462a08d8.png)

This PR will fix #343 issue