### PR TITLE
Add getcaddy

### DIFF
--- a/domains
+++ b/domains
@@ -294,3 +294,5 @@
 .coursera-apps.org
 .coursera.com
 .javacardos.com
+.getcaddy.com
+.caddyserver.com


### PR DESCRIPTION
`getcaddy.com` is used for installing Caddy web server. It downloads a script which determines architecture, verifies downloaded binaries and installs them. The script (`curl https://getcaddy.com`) tries to download from `caddyserver.com` which is also added to the list.