### PR TITLE
add jfrog.io

### DIFF
--- a/domains
+++ b/domains
@@ -298,3 +298,4 @@
 .caddyserver.com
 .bit.dev
 .clamav.net
+.jfrog.io


### PR DESCRIPTION
openjdk repo for debian-based distros
useful for installing more updated packages and legacy packages like openjdk-8-jre on debian buster without enabling unstable repo