### PR TITLE
Add cljdoc

### DIFF
--- a/domains
+++ b/domains
@@ -311,3 +311,5 @@
 .surveys.google.com
 .jfrog.io
 .csb.app
+.cljdoc.org
+


### PR DESCRIPTION
Add cljdoc.org domain. cljdoc is a website building & hosting documentation for Clojure/Script libraries.