### PR TITLE
added cncf.io

### DIFF
--- a/domains
+++ b/domains
@@ -317,3 +317,4 @@
 .cljdoc.org
 .vuetifyjs.com
 .wpastra.com
+.cncf.io


### PR DESCRIPTION
Cloud Native Computing Foundation. Some subdomains  are not anymore accessible from Iran IPs. such as:  landscape.cncf.io