### PR TITLE
add mailgun.net

### DIFF
--- a/domains
+++ b/domains
@@ -317,3 +317,4 @@
 .cljdoc.org
 .vuetifyjs.com
 .wpastra.com
+.mailgun.net


### PR DESCRIPTION
It's necessary for api.mailgun.net, but I haven't seen any harm adding its domain and all its subdomains too.