### PR TITLE
Remove slack

### DIFF
--- a/domains
+++ b/domains
@@ -51,7 +51,6 @@
 .php.net
 .mybridge.co
 .githubusercontent.com
-.slack.com
 .play.google.com
 .algolia.com
 .algolianet.com
@@ -251,7 +250,6 @@
 .gitlab-static.net
 .releases.hashicorp.com
 .livefyre.com
-.slack-edge.com
 .cloudera.com
 .apache.org
 .vagrantup.com


### PR DESCRIPTION
Remove slack.com & slack-edge.com as it's not banned in Iran, also proxying these domains in some ways, its messenger will not work.