### PR TITLE
add jetbrains gradle repository

### DIFF
--- a/domains
+++ b/domains
@@ -33,6 +33,7 @@
 .googletagservices.com
 .alexa.com
 .getliner.com
+.jetbrains.space
 .ngrok.com
 .ngrok.io
 .gradle-dn.com


### PR DESCRIPTION
This is the url that is used to resolve jetbrains compose gradle dependencies: https://maven.pkg.jetbrains.space/public/p/compose/dev