### PR TITLE
add .deno.land

### DIFF
--- a/domains
+++ b/domains
@@ -436,3 +436,4 @@
 .freenom.com
 .quilljs.com
 .hackerrank.com
+.deno.land


### PR DESCRIPTION
> `deno.land/x` is a hosting service for Deno scripts. It caches releases of open source modules stored on GitHub and serves them at one easy to remember domain.

Due to sanctions, the [website](deno.land) has been blocked.