### PR TITLE
🆕 add timedoctor.com to domains

### DIFF
--- a/domains
+++ b/domains
@@ -68,6 +68,7 @@
 .code.videolan.org
 .videolan.org
 .google-analytics.com
+.timedoctor.com
 .conan.io
 .oddrun.ir
 .proandroiddev.com


### PR DESCRIPTION
This site is for time-tracking, and it blocks Iranian IPs due to US sanctions.
Shecan supports this site and you can verify that from [This link](https://shecan.ir/?url=http%3A%2F%2Ftimedoctor.com#report) 