### PR TITLE
Added planet.com which provides satellite imagery

### DIFF
--- a/domains
+++ b/domains
@@ -494,3 +494,4 @@
 .serverpilot.io
 .pytorch.org
 .insomnia.rest
+.planet.com


### PR DESCRIPTION
planet.com provides satellite imagery and denies Iranians access to its domain and subdomains