### PR TITLE
feature: add --status option to fod.sh script

### DIFF
--- a/fodcmd/fod.sh
+++ b/fodcmd/fod.sh
@@ -19,11 +19,20 @@ function fod(){
             unset NO_PROXY
             echo "disable fod proxy !"
         ;;
+        "--status" | "-s")
+            if [[ $http_proxy == 'http://fodev.org:8118/' ]]
+            then
+                echo 'fod proxy is ENABLED !'
+            else
+                echo 'fod proxy is DISABLED !'
+            fi
+        ;;
         *)
-            echo "Usage : fod [-e | --enable] [-d | --disable]"
+            echo "Usage : fod [-e | --enable] [-d | --disable] [-s | --status]"
             echo "Example : "
-            echo "  fod --enable for enable fod proxy "
-            echo "  fod --disable for disable fod proxy "
+            echo "  fod --enable to enable fod proxy "
+            echo "  fod --disable to disable fod proxy "
+            echo "  fod --status to check fod proxy status "
         ;;
     esac
 }


### PR DESCRIPTION
add the --status option to the fod.sh script, so users can check whether or not the proxy is enabled.