### PR TITLE
Add mouser.com

### DIFF
--- a/domains
+++ b/domains
@@ -431,6 +431,7 @@
 .vmcdn.com
 .nirsoft.net
 .digikey.com
+.mouser.com
 .download.01.org
 .packagesource.com
 .wtfismyip.com


### PR DESCRIPTION
### Description
Mouser is an electronic parts supplier, it's a vendor similar to DigiKey, which is already in the fodev list. Mouser started giving 403 status codes to visitors, so it should be included in the list.