### PR TITLE
Add Arduino downloads domain

### DIFF
--- a/domains
+++ b/domains
@@ -601,3 +601,4 @@
 .8xr.io
 .litespeedtech.com
 .buf.build
+.downloads.arduino.cc


### PR DESCRIPTION
### Description
Under sanctions in Iran, it's used to download board definitions, core packages, libraries and more
