### PR TITLE
Add spotifycdn.com to domains

### DIFF
--- a/domains
+++ b/domains
@@ -426,6 +426,7 @@
 .microchip.com
 .codesandbox.io
 .spotify.com
+.spotifycdn.com
 .scdn.co
 .godbolt.org
 .zoom.us


### PR DESCRIPTION
This pull request adds spotifycdn.com to the list of allowed domains. The addition of this domain is necessary to ensure that resources served from Spotify's CDN can be properly accessed and utilized within our application.